### PR TITLE
feat: enrich discovered LM Studio model metadata

### DIFF
--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -7,6 +7,26 @@ import type { LMStudioModel } from '../types'
 
 const modelStatusCache = new ModelStatusCache()
 
+function supportsVisionInput(model: LMStudioModel): boolean {
+  if (typeof model.capabilities === 'object' && model.capabilities !== null && !Array.isArray(model.capabilities)) {
+    return Boolean(model.capabilities.vision)
+  }
+
+  return model.type === 'vlm'
+}
+
+function supportsToolCall(model: LMStudioModel): boolean {
+  if (Array.isArray(model.capabilities)) {
+    return model.capabilities.includes('tool_use')
+  }
+
+  if (typeof model.capabilities === 'object' && model.capabilities !== null) {
+    return Boolean(model.capabilities.trained_for_tool_use)
+  }
+
+  return false
+}
+
 export async function enhanceConfig(
   config: any,
   _client: PluginInput['client'], // client not used but kept for interface compatibility
@@ -82,6 +102,13 @@ export async function enhanceConfig(
             id: model.id,
             name: formatModelName(model),
           }
+
+          const contextLength = model.loaded_context_length ?? model.max_context_length
+          if (contextLength) {
+            modelConfig.limit = {
+              context: contextLength,
+            }
+          }
           
           // Add owner if available
           if (owner) {
@@ -98,9 +125,13 @@ export async function enhanceConfig(
           } else if (modelType === 'chat') {
             chatModelsCount++
             modelConfig.modalities = {
-              input: ["text", "image"],
+              input: supportsVisionInput(model) ? ["text", "image"] : ["text"],
               output: ["text"]
             }
+          }
+
+          if (supportsToolCall(model)) {
+            modelConfig.toolCall = true
           }
 
           discoveredModels[modelKey] = modelConfig
@@ -153,4 +184,3 @@ export async function enhanceConfig(
     toastNotifier.warning("Plugin configuration failed", "Configuration Error").catch(() => {})
   }
 }
-

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,13 +2,54 @@
 export interface LMStudioModel {
   id: string
   object: string
-  created: number
-  owned_by: string
+  created?: number
+  owned_by?: string
+  display_name?: string
+  type?: string
+  publisher?: string
+  arch?: string
+  compatibility_type?: string
+  max_context_length?: number
+  loaded_context_length?: number
+  capabilities?: string[] | {
+    vision?: boolean
+    trained_for_tool_use?: boolean
+  }
+  loaded_instances?: Array<{
+    id?: string
+    config?: {
+      context_length?: number
+    }
+  }>
 }
 
 export interface LMStudioModelsResponse {
   object: string
   data: LMStudioModel[]
+}
+
+export interface LMStudioAPIV1Model {
+  type?: string
+  publisher?: string
+  key: string
+  display_name?: string
+  architecture?: string
+  format?: string
+  max_context_length?: number
+  capabilities?: {
+    vision?: boolean
+    trained_for_tool_use?: boolean
+  }
+  loaded_instances?: Array<{
+    id?: string
+    config?: {
+      context_length?: number
+    }
+  }>
+}
+
+export interface LMStudioAPIV1ModelsResponse {
+  models?: LMStudioAPIV1Model[]
 }
 
 export type ModelType = 'chat' | 'embedding' | 'unknown'

--- a/src/utils/format-model-name.ts
+++ b/src/utils/format-model-name.ts
@@ -16,6 +16,10 @@ export function extractModelOwner(modelId: string): string | undefined {
  * Creates readable titles like "Qwen3 30B A3B" instead of "qwen/qwen3-30b-a3b"
  */
 export function formatModelName(model: LMStudioModel): string {
+  if (model.display_name) {
+    return model.display_name
+  }
+
   const { id } = model
   
   // Extract parts from model ID
@@ -60,4 +64,3 @@ export function formatModelName(model: LMStudioModel): string {
   
   return tokens
 }
-

--- a/src/utils/lmstudio-api.ts
+++ b/src/utils/lmstudio-api.ts
@@ -1,7 +1,14 @@
-import type { LMStudioModel, LMStudioModelsResponse } from '../types'
+import type {
+  LMStudioAPIV1Model,
+  LMStudioAPIV1ModelsResponse,
+  LMStudioModel,
+  LMStudioModelsResponse,
+} from '../types'
 
 const DEFAULT_LM_STUDIO_URL = "http://127.0.0.1:1234"
 const LM_STUDIO_MODELS_ENDPOINT = "/v1/models"
+const LM_STUDIO_MODELS_ENDPOINT_API_V0 = "/api/v0/models"
+const LM_STUDIO_MODELS_ENDPOINT_API_V1 = "/api/v1/models"
 
 // Normalize base URL to ensure consistent format
 export function normalizeBaseURL(baseURL: string = DEFAULT_LM_STUDIO_URL): string {
@@ -22,6 +29,42 @@ export function buildAPIURL(baseURL: string, endpoint: string = LM_STUDIO_MODELS
   return `${normalized}${endpoint}`
 }
 
+function resolveLoadedContextLength(model: LMStudioAPIV1Model): number | undefined {
+  return model.loaded_instances?.find(instance => instance?.config?.context_length)?.config?.context_length
+}
+
+function normalizeAPIV1Model(model: LMStudioAPIV1Model): LMStudioModel {
+  return {
+    id: model.key,
+    object: "model",
+    display_name: model.display_name,
+    type: model.type,
+    publisher: model.publisher,
+    arch: model.architecture,
+    compatibility_type: model.format,
+    max_context_length: model.max_context_length,
+    loaded_context_length: resolveLoadedContextLength(model),
+    capabilities: model.capabilities,
+    loaded_instances: model.loaded_instances,
+  }
+}
+
+async function fetchJSON<T>(url: string): Promise<T | null> {
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    signal: AbortSignal.timeout(3000),
+  })
+
+  if (!response.ok) {
+    return null
+  }
+
+  return (await response.json()) as T
+}
+
 // Check if LM Studio is accessible
 export async function checkLMStudioHealth(baseURL: string = DEFAULT_LM_STUDIO_URL): Promise<boolean> {
   try {
@@ -39,21 +82,22 @@ export async function checkLMStudioHealth(baseURL: string = DEFAULT_LM_STUDIO_UR
 // Discover models from LM Studio API
 export async function discoverLMStudioModels(baseURL: string = DEFAULT_LM_STUDIO_URL): Promise<LMStudioModel[]> {
   try {
-    const url = buildAPIURL(baseURL)
-    const response = await fetch(url, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      signal: AbortSignal.timeout(3000),
-    })
-
-    if (!response.ok) {
-      return []
+    const apiV1Data = await fetchJSON<LMStudioAPIV1ModelsResponse>(
+      buildAPIURL(baseURL, LM_STUDIO_MODELS_ENDPOINT_API_V1)
+    )
+    if (apiV1Data?.models?.length) {
+      return apiV1Data.models.map(normalizeAPIV1Model)
     }
 
-    const data = (await response.json()) as LMStudioModelsResponse
-    return data.data ?? []
+    const apiV0Data = await fetchJSON<LMStudioModelsResponse>(
+      buildAPIURL(baseURL, LM_STUDIO_MODELS_ENDPOINT_API_V0)
+    )
+    if (apiV0Data?.data?.length) {
+      return apiV0Data.data
+    }
+
+    const openAIData = await fetchJSON<LMStudioModelsResponse>(buildAPIURL(baseURL))
+    return openAIData?.data ?? []
   } catch (error) {
     throw new Error(`Failed to discover models: ${error instanceof Error ? error.message : String(error)}`)
   }

--- a/test/lmstudio-api.test.ts
+++ b/test/lmstudio-api.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { discoverLMStudioModels } from '../src/utils/lmstudio-api.ts'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+if (!global.AbortSignal.timeout) {
+  global.AbortSignal.timeout = vi.fn(() => {
+    const controller = new AbortController()
+    setTimeout(() => controller.abort(), 3000)
+    return controller.signal
+  })
+}
+
+describe('discoverLMStudioModels', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    mockFetch.mockReset()
+  })
+
+  it('prefers LM Studio api/v1 metadata when available', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        models: [
+          {
+            key: 'qwen3.6-35b-a3b',
+            display_name: 'Qwen3.6 35B A3B UD',
+            type: 'vlm',
+            publisher: 'unsloth',
+            architecture: 'qwen35moe',
+            format: 'gguf',
+            max_context_length: 262144,
+            capabilities: {
+              vision: true,
+              trained_for_tool_use: true,
+            },
+            loaded_instances: [
+              {
+                id: 'qwen3.6-35b-a3b',
+                config: {
+                  context_length: 131072,
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    })
+
+    const models = await discoverLMStudioModels()
+
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: 'qwen3.6-35b-a3b',
+        display_name: 'Qwen3.6 35B A3B UD',
+        type: 'vlm',
+        publisher: 'unsloth',
+        arch: 'qwen35moe',
+        compatibility_type: 'gguf',
+        max_context_length: 262144,
+        loaded_context_length: 131072,
+      }),
+    ])
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch.mock.calls[0]?.[0]).toContain('/api/v1/models')
+  })
+
+  it('falls back to api/v0 and then openai-compatible models', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          object: 'list',
+          data: [
+            {
+              id: 'fallback-model',
+              object: 'model',
+              type: 'llm',
+              max_context_length: 8192,
+            },
+          ],
+        }),
+      })
+
+    const models = await discoverLMStudioModels()
+
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: 'fallback-model',
+        max_context_length: 8192,
+      }),
+    ])
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(mockFetch.mock.calls[1]?.[0]).toContain('/api/v0/models')
+  })
+
+  it('falls back to /v1/models when richer endpoints are unavailable', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          object: 'list',
+          data: [
+            {
+              id: 'openai-compatible-model',
+              object: 'model',
+              owned_by: 'organization_owner',
+            },
+          ],
+        }),
+      })
+
+    const models = await discoverLMStudioModels()
+
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: 'openai-compatible-model',
+      }),
+    ])
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(mockFetch.mock.calls[2]?.[0]).toContain('/v1/models')
+  })
+})

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -20,7 +20,7 @@ describe('LMStudio Plugin', () => {
 
   beforeEach(async () => {
     // Reset fetch mock
-    mockFetch.mockClear()
+    mockFetch.mockReset()
     
     // Mock client
     mockClient = {
@@ -125,7 +125,22 @@ describe('LMStudio Plugin', () => {
         ok: true
       })
 
-      // Mock models response
+      // Mock api/v1 unavailable, api/v0 success, cache warm success
+      mockFetch.mockResolvedValueOnce({
+        ok: false
+      })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'test-model-1', object: 'model', created: 1234567890, owned_by: 'local' },
+            { id: 'test-model-2', object: 'model', created: 1234567890, owned_by: 'local' }
+          ]
+        })
+      })
+      mockFetch.mockResolvedValueOnce({
+        ok: false
+      })
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -176,6 +191,83 @@ describe('LMStudio Plugin', () => {
           name: 'New Model'
         })
       })
+    })
+
+    it('should include context limits and capabilities from LM Studio metadata', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            models: [
+              {
+                key: 'qwen3.6-35b-a3b',
+                display_name: 'Qwen3.6 35B A3B UD',
+                type: 'vlm',
+                max_context_length: 262144,
+                capabilities: {
+                  vision: true,
+                  trained_for_tool_use: true
+                },
+                loaded_instances: [
+                  {
+                    id: 'qwen3.6-35b-a3b',
+                    config: {
+                      context_length: 131072
+                    }
+                  }
+                ]
+              }
+            ]
+          })
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            models: [
+              {
+                key: 'qwen3.6-35b-a3b',
+                display_name: 'Qwen3.6 35B A3B UD',
+                type: 'vlm',
+                max_context_length: 262144,
+                capabilities: {
+                  vision: true,
+                  trained_for_tool_use: true
+                }
+              }
+            ]
+          })
+        })
+
+      const config: any = {
+        provider: {
+          lmstudio: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'LM Studio (local)',
+            options: { baseURL: 'http://127.0.0.1:1234/v1' },
+            models: {}
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.lmstudio.models['qwen3_6-35b-a3b']).toEqual(
+        expect.objectContaining({
+          id: 'qwen3.6-35b-a3b',
+          name: 'Qwen3.6 35B A3B UD',
+          toolCall: true,
+          limit: {
+            context: 131072
+          },
+          modalities: {
+            input: ['text', 'image'],
+            output: ['text']
+          }
+        })
+      )
     })
 
     it('should handle LM Studio offline gracefully', async () => {


### PR DESCRIPTION
## What changed

This updates model discovery to prefer LM Studio's richer metadata endpoints before falling back to the OpenAI-compatible `/v1/models` response.

The plugin now:
- prefers `/api/v1/models`, then `/api/v0/models`, then `/v1/models`
- carries forward LM Studio display names when available
- populates `limit.context` from `loaded_context_length` or `max_context_length`
- derives `modalities` more accurately from LM Studio capabilities instead of assuming image support for every chat model
- marks models as `toolCall: true` when LM Studio reports tool-use support
- adds focused tests for the discovery fallback chain and config enrichment behavior

## Why this changed

LM Studio exposes much richer model metadata on its native API endpoints than on the OpenAI-compatible `/v1/models` endpoint.

Before this change, the plugin only read `/v1/models`, so discovered models were missing important runtime metadata such as context length. That made OpenCode unable to surface model context limits even though LM Studio already knew them.

## Impact

Users who rely on automatic LM Studio model discovery will now get:
- context limits for discovered models
- more accurate display names
- more accurate image/tool capability metadata
- no regression for setups where only the OpenAI-compatible endpoint is available

## Validation

- `npm run test:run`
- `npm run typecheck`
