### PR TITLE
feat: support /api/v0/models for context length discovery

### DIFF
--- a/.~lock.README.md#
+++ b/.~lock.README.md#
@@ -1,0 +1,1 @@
+,magdiel,Laptop,21.04.2026 21:46,/home/magdiel/.local/share/onlyoffice;

--- a/.~lock.README.md#
+++ b/.~lock.README.md#
@@ -1,1 +1,0 @@
-,magdiel,Laptop,21.04.2026 21:46,/home/magdiel/.local/share/onlyoffice;

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ OpenCode plugin for enhanced LM Studio support with auto-detection and dynamic m
 ## Features
 
 - **Auto-detection**: Automatically detects LM Studio running on common ports (1234, 8080, 11434)
-- **Dynamic Model Discovery**: Queries LM Studio's `/v1/models` endpoint to discover available models
+- **Dynamic Model Discovery**: Queries LM Studio's `/api/v0/models` endpoint (fallback: `/v1/models`) to discover available models
+- **Context Length Discovery**: Reads `loaded_context_length` / `max_context_length` from LM Studio and exposes them as `limit.context`, enabling OpenCode features like auto-compaction
 - **Smart Model Formatting**: Automatically formats model names for better readability (e.g., "Qwen3 30B A3B" instead of "qwen/qwen3-30b-a3b")
 - **Organization Owner Extraction**: Extracts and sets `organizationOwner` field from model IDs
 - **Health Check Monitoring**: Verifies LM Studio is accessible before attempting operations
@@ -82,8 +83,8 @@ The plugin will automatically discover and add any additional models available i
 1. On OpenCode startup, the plugin's `config` hook is called
 2. If an `lmstudio` provider is found, it checks if LM Studio is accessible
 3. If not configured, it attempts to auto-detect LM Studio on common ports
-4. If accessible, it queries the `/v1/models` endpoint
-5. Discovered models are merged into your configuration
+4. If accessible, it queries `/api/v0/models` for rich metadata (context length, model type, publisher), falling back to `/v1/models` on older LM Studio versions (< 0.3.5)
+5. Discovered models are merged into your configuration, including `limit.context` when available — this lets OpenCode enable auto-compaction based on the context window actually configured in LM Studio
 6. The enhanced configuration is used for the current session
 
 ## Requirements

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -1,9 +1,11 @@
 import { ModelStatusCache } from '../cache/model-status-cache'
 import { ToastNotifier } from '../ui/toast-notifier'
 import { categorizeModel, formatModelName, extractModelOwner } from '../utils'
-import { normalizeBaseURL, checkLMStudioHealth, discoverLMStudioModels, autoDetectLMStudio } from '../utils/lmstudio-api'
+import { normalizeBaseURL, checkLMStudioHealth, discoverLMStudioModels, discoverLMStudioModelsV0, autoDetectLMStudio } from '../utils/lmstudio-api'
 import type { PluginInput } from '@opencode-ai/plugin'
-import type { LMStudioModel } from '../types'
+import type { LMStudioModel, LMStudioModelV0, ModelType } from '../types'
+
+const MAX_OUTPUT_TOKENS_CAP = 16384
 
 const modelStatusCache = new ModelStatusCache()
 
@@ -49,15 +51,27 @@ export async function enhanceConfig(
       return
     }
 
-    // Try to discover models from LM Studio API
-    let models: LMStudioModel[]
+    // Try /api/v0/models first (exposes context length) then fall back to /v1/models
+    let models: Array<LMStudioModel | LMStudioModelV0> = []
+    let usedV0 = false
     try {
-      models = await discoverLMStudioModels(baseURL)
+      const v0Models = await discoverLMStudioModelsV0(baseURL)
+      if (v0Models !== null) {
+        models = v0Models
+        usedV0 = true
+      } else {
+        console.warn("[opencode-lmstudio] /api/v0/models unavailable (LMStudio < 0.3.5?), falling back to /v1/models — context length discovery disabled")
+        models = await discoverLMStudioModels(baseURL)
+      }
     } catch (error) {
-      console.warn("[opencode-lmstudio] Model discovery failed", { 
-        error: error instanceof Error ? error.message : String(error) 
-      })
-      return
+      try {
+        models = await discoverLMStudioModels(baseURL)
+      } catch (fallbackError) {
+        console.warn("[opencode-lmstudio] Model discovery failed", {
+          error: fallbackError instanceof Error ? fallbackError.message : String(fallbackError)
+        })
+        return
+      }
     }
     
     if (models.length > 0) {
@@ -73,16 +87,19 @@ export async function enhanceConfig(
         if (!/^[a-zA-Z0-9_-]+$/.test(modelKey)) {
           modelKey = model.id.replace(/[^a-zA-Z0-9_-]/g, "_")
         }
-        
+
         // Only add if not already configured
         if (!existingModels[modelKey] && !existingModels[model.id]) {
-          const modelType = categorizeModel(model.id)
-          const owner = extractModelOwner(model.id)
+          const v0Model = usedV0 ? (model as LMStudioModelV0) : null
+          const modelType: ModelType = v0Model
+            ? (v0Model.type === 'embeddings' ? 'embedding' : 'chat')
+            : categorizeModel(model.id)
+          const owner = v0Model?.publisher || extractModelOwner(model.id)
           const modelConfig: any = {
             id: model.id,
-            name: formatModelName(model),
+            name: formatModelName(model as LMStudioModel),
           }
-          
+
           // Add owner if available
           if (owner) {
             modelConfig.organizationOwner = owner
@@ -100,6 +117,17 @@ export async function enhanceConfig(
             modelConfig.modalities = {
               input: ["text", "image"],
               output: ["text"]
+            }
+          }
+
+          // Prefer loaded_context_length (user-configured) over max_context_length (model ceiling)
+          if (v0Model) {
+            const contextLength = v0Model.loaded_context_length ?? v0Model.max_context_length
+            if (contextLength && contextLength > 0) {
+              modelConfig.limit = {
+                context: contextLength,
+                output: Math.min(Math.floor(contextLength / 4), MAX_OUTPUT_TOKENS_CAP)
+              }
             }
           }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,24 @@ export interface LMStudioModelsResponse {
   data: LMStudioModel[]
 }
 
+export interface LMStudioModelV0 {
+  id: string
+  object: string
+  type: 'llm' | 'vlm' | 'embeddings'
+  publisher: string
+  arch: string
+  compatibility_type: string
+  quantization: string
+  state: 'loaded' | 'not-loaded' | 'loading'
+  max_context_length: number
+  loaded_context_length?: number
+}
+
+export interface LMStudioModelsV0Response {
+  object: 'list'
+  data: LMStudioModelV0[]
+}
+
 export type ModelType = 'chat' | 'embedding' | 'unknown'
 
 export type LoadingStatus = 'not_loaded' | 'loading' | 'loaded' | 'error'

--- a/src/utils/lmstudio-api.ts
+++ b/src/utils/lmstudio-api.ts
@@ -1,7 +1,8 @@
-import type { LMStudioModel, LMStudioModelsResponse } from '../types'
+import type { LMStudioModel, LMStudioModelsResponse, LMStudioModelV0, LMStudioModelsV0Response } from '../types'
 
 const DEFAULT_LM_STUDIO_URL = "http://127.0.0.1:1234"
 const LM_STUDIO_MODELS_ENDPOINT = "/v1/models"
+const LM_STUDIO_MODELS_V0_ENDPOINT = "/api/v0/models"
 
 // Normalize base URL to ensure consistent format
 export function normalizeBaseURL(baseURL: string = DEFAULT_LM_STUDIO_URL): string {
@@ -57,6 +58,29 @@ export async function discoverLMStudioModels(baseURL: string = DEFAULT_LM_STUDIO
   } catch (error) {
     throw new Error(`Failed to discover models: ${error instanceof Error ? error.message : String(error)}`)
   }
+}
+
+// Returns null on 404 so callers can fall back to /v1/models on older LMStudio versions
+export async function discoverLMStudioModelsV0(baseURL: string = DEFAULT_LM_STUDIO_URL): Promise<LMStudioModelV0[] | null> {
+  const url = buildAPIURL(baseURL, LM_STUDIO_MODELS_V0_ENDPOINT)
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    signal: AbortSignal.timeout(3000),
+  })
+
+  if (response.status === 404) {
+    return null
+  }
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+  }
+
+  const data = (await response.json()) as LMStudioModelsV0Response
+  return data.data ?? []
 }
 
 // Get currently loaded/active models from LM Studio (bypass cache)

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -178,6 +178,142 @@ describe('LMStudio Plugin', () => {
       })
     })
 
+    it('should extract context length from /api/v0/models into limit.context', async () => {
+      // health check
+      mockFetch.mockResolvedValueOnce({ ok: true })
+      // /api/v0/models
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          object: 'list',
+          data: [{
+            id: 'llama-3-8b',
+            object: 'model',
+            type: 'llm',
+            publisher: 'meta',
+            arch: 'llama',
+            compatibility_type: 'gguf',
+            quantization: 'Q4_K_M',
+            state: 'loaded',
+            max_context_length: 131072,
+            loaded_context_length: 8192
+          }]
+        })
+      })
+      // cache warm-up fetch
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ id: 'llama-3-8b', object: 'model', created: 0, owned_by: 'meta' }] })
+      })
+
+      const config: any = {
+        provider: {
+          lmstudio: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'LM Studio (local)',
+            options: { baseURL: 'http://127.0.0.1:1234/v1' }
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.lmstudio.models?.['llama-3-8b']).toEqual(
+        expect.objectContaining({
+          id: 'llama-3-8b',
+          organizationOwner: 'meta',
+          limit: {
+            context: 8192,
+            output: 2048
+          }
+        })
+      )
+    })
+
+    it('should fall back to /v1/models when /api/v0/models returns 404', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      // health check
+      mockFetch.mockResolvedValueOnce({ ok: true })
+      // /api/v0/models returns 404
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found' })
+      // fallback /v1/models
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'legacy-model', object: 'model', created: 0, owned_by: 'local' }]
+        })
+      })
+      // cache warm-up
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ id: 'legacy-model', object: 'model', created: 0, owned_by: 'local' }] })
+      })
+
+      const config: any = {
+        provider: {
+          lmstudio: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'LM Studio (local)',
+            options: { baseURL: 'http://127.0.0.1:1234/v1' }
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v0/models unavailable')
+      )
+      expect(config.provider.lmstudio.models?.['legacy-model']).toBeDefined()
+      expect(config.provider.lmstudio.models?.['legacy-model']?.limit).toBeUndefined()
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('should use max_context_length when loaded_context_length is absent and cap output at 16384', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          object: 'list',
+          data: [{
+            id: 'unloaded-model',
+            object: 'model',
+            type: 'llm',
+            publisher: 'meta',
+            arch: 'llama',
+            compatibility_type: 'gguf',
+            quantization: 'Q4_K_M',
+            state: 'not-loaded',
+            max_context_length: 131072
+          }]
+        })
+      })
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] })
+      })
+
+      const config: any = {
+        provider: {
+          lmstudio: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'LM Studio (local)',
+            options: { baseURL: 'http://127.0.0.1:1234/v1' }
+          }
+        }
+      }
+
+      await pluginHooks.config(config)
+
+      expect(config.provider.lmstudio.models?.['unloaded-model']?.limit).toEqual({
+        context: 131072,
+        output: 16384
+      })
+    })
+
     it('should handle LM Studio offline gracefully', async () => {
       mockFetch.mockRejectedValue(new Error('Connection refused'))
 


### PR DESCRIPTION
Query LM Studio's native /api/v0/models endpoint to read loaded_context_length and max_context_length, exposed via limit.context in the model config. This enables OpenCode features like auto-compaction based on the context window actually configured in LM Studio.

Falls back transparently to /v1/models on older LM Studio versions (< 0.3.5) with a warning log.

- Add LMStudioModelV0 types for /api/v0/models response
- New discoverLMStudioModelsV0() function with 404→null fallback signal
- enhance-config: prioritize v0 endpoint, map loaded_context_length to limit.context
- Output tokens capped at 16384, 1/4 of context window
- 3 new tests covering v0 success, 404 fallback, max_context_length handling
- Update README features and How It Works sections

Co-Authored-By: Claude Opus 4.7