### PR TITLE
Fix for unsupported model type for OpenCode

### DIFF
--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -88,13 +88,11 @@ export async function enhanceConfig(
             modelConfig.organizationOwner = owner
           }
 
-          // Add additional metadata based on model type
+          // Skip embedding models — opencode only supports "text", "audio", "image", "video", "pdf"
+          // as valid output modalities, so embedding models cannot be registered
           if (modelType === 'embedding') {
             embeddingModelsCount++
-            modelConfig.modalities = {
-              input: ["text"],
-              output: ["embedding"]
-            }
+            continue
           } else if (modelType === 'chat') {
             chatModelsCount++
             modelConfig.modalities = {


### PR DESCRIPTION
As of the latest update, OpenCode doesn't support loading embedding models from LM-Studio, which this plugin still provides. A good solution is to just filter out the embedding models from being accessible to OpenCode. 

It is understandable that embedding models may have other purposes but this is a plugin for OpenCode and if OpenCode doesn't want to use embedding models, there's no reason for them to be in the plugin. 