### PR TITLE
fix: don't emit invalid "embedding" output modality (crashes TUI on startup)

### DIFF
--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -91,10 +91,10 @@ export async function enhanceConfig(
           // Add additional metadata based on model type
           if (modelType === 'embedding') {
             embeddingModelsCount++
-            modelConfig.modalities = {
-              input: ["text"],
-              output: ["embedding"]
-            }
+            // NOTE: OpenCode's model schema only accepts text/audio/image/video/pdf
+            // as modality values. Emitting "embedding" causes a schema rejection that
+            // crashes the server on startup, so embedding models are registered without
+            // an explicit `modalities` field (OpenCode applies its defaults).
           } else if (modelType === 'chat') {
             chatModelsCount++
             modelConfig.modalities = {


### PR DESCRIPTION
## Problem

After updating OpenCode (reproduced on `1.16.2`), the TUI crashes on startup with:

```
config.get: Expected "text" | "audio" | "image" | "video" | "pdf", got "embedding"
  at ["provider"]["lmstudio"]["models"]["text-embedding-...""]["modalities"]["output"][0]
... tui bootstrap failed
```

Recent OpenCode releases tightened model-config schema validation. The plugin sets `modalities.output = ["embedding"]` for embedding models in `enhance-config.ts`, but `embedding` is no longer an accepted modality value — so the whole config fails validation and OpenCode refuses to boot whenever LM Studio exposes an embedding model (e.g. `text-embedding-nomic-embed-text-v1.5`).

## Fix

Register embedding models **without** an explicit `modalities` field, letting OpenCode apply its defaults instead of rejecting the config. Chat models are unaffected. Embedding models are still discovered and counted (the "only embedding models found" guidance still works).

## Verification

- `npm run typecheck` ✅
- `npm run test:run` ✅ (16/16)
- Reproduced the crash locally with an LM Studio instance exposing an embedding model, then confirmed the fix: no more `schema rejection` / `tui bootstrap failed`, providers initialize, and chat models resolve and reach LM Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)