### PR TITLE
fix: surface LM Studio tool capability modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,13 @@ context, capped at 8,192 tokens. An explicit user limit always wins.
 
 ### Tool training and reasoning
 
-The plugin does not convert `trained_for_tool_use: false` into
-`tool_call: false`. LM Studio documents default tool use separately from native
-tool training, while OpenCode enables tools when `tool_call` is omitted.
+LM Studio documents native and default tool-use modes, and says every model has
+at least default tool support. The plugin sets `tool_call: true` for discovered
+LLMs rather than treating `trained_for_tool_use: false` as "tools unsupported."
+The structured discovery log groups models into `toolUse.native`,
+`toolUse.default`, and `toolUse.unknown`, so lower-reliability default handling
+is visible without disabling it. Runtime malformed-call detection is not
+claimed because LM Studio can return that text as ordinary assistant content.
 
 LM Studio reasoning settings are also left unmapped because OpenCode's
 `reasoning` flag is not documented as an equivalent field for the

--- a/docs/releases/v1.0.0-rc.2.md
+++ b/docs/releases/v1.0.0-rc.2.md
@@ -39,6 +39,8 @@ The plugin does not fall back to the previous `/api/v0` discovery shape. Stable
 - Preserves native model `key` values and uses `display_name` in OpenCode.
 - Includes `type: "llm"`; excludes loaded and unloaded embedding records.
 - Maps `capabilities.vision` to image input and attachment support.
+- Keeps tool calls enabled for LM Studio's native and default tool-use modes,
+  and reports each model's mode through structured discovery diagnostics.
 - Uses `max_context_length` for unloaded, on-demand models.
 - Uses loaded instance `config.context_length` when active.
 - Uses the minimum context when multiple instances share a model key.
@@ -47,8 +49,9 @@ The plugin does not fall back to the previous `/api/v0` discovery shape. Stable
 
 LM Studio does not report a distinct generation limit, so the plugin's output
 reserve remains explicit policy: one quarter of effective context, capped at
-8,192 tokens. `trained_for_tool_use` and reasoning settings are not translated
-into non-equivalent OpenCode fields. The full rationale is in
+8,192 tokens. `trained_for_tool_use` is used as a native-vs-default diagnostic,
+not as a reason to disable default tool support. Reasoning settings are not
+translated into a non-equivalent OpenCode field. The full rationale is in
 [`docs/v1-contract.md`](https://github.com/agustif/opencode-lmstudio/blob/v1.0.0-rc.2/docs/v1-contract.md).
 
 ## Release evidence

--- a/docs/v1-contract.md
+++ b/docs/v1-contract.md
@@ -43,6 +43,7 @@ Automatic discovery checks only LM Studio's documented default address,
 | `type: "llm"` | chat model | Include |
 | `type: "embedding"` | none | Exclude from the chat provider |
 | `capabilities.vision` | `attachment`, input modalities | Add image input only when true |
+| `capabilities.trained_for_tool_use` | `tool_call`, structured diagnostics | Keep tools enabled; report native or default handling |
 | `max_context_length` | `limit.context` | Use when no instance is loaded |
 | loaded `config.context_length` | `limit.context` | Use one active value, or the minimum for multiple instances |
 
@@ -57,11 +58,20 @@ an explicit conservative policy: one quarter of effective context, capped at
 8,192 tokens. This is plugin policy, not LM Studio metadata. Explicit user
 limits override it.
 
-`capabilities.trained_for_tool_use` reports whether a model was trained
-natively for tool use. LM Studio separately documents a default tool-use path
-for other models, and OpenCode defaults an omitted `tool_call` field to true.
-The plugin therefore does not translate a false training flag into
-`tool_call: false`.
+`capabilities.trained_for_tool_use` reports whether LM Studio uses native or
+default tool handling. LM Studio documents that every model has at least
+default tool support, although models without native training may produce
+malformed calls and results vary by model. The plugin therefore sets
+`tool_call: true` for discovered LLMs and never translates a false training
+flag into `tool_call: false`.
+
+The structured `Discovered LM Studio models` log groups model keys under
+`toolUse.native`, `toolUse.default`, and `toolUse.unknown`. This exposes the
+static quality signal without printing to ACP stdout or pretending that
+default support is unavailable. Neither LM Studio's response nor OpenCode's
+plugin hooks expose a reliable runtime event when malformed tool-call text is
+returned as ordinary assistant content, so the plugin does not guess by
+scanning model output.
 
 LM Studio's `capabilities.reasoning` describes its public reasoning settings.
 OpenCode's `reasoning` boolean controls provider behavior and is not documented

--- a/scripts/smoke-opencode-resolver.ts
+++ b/scripts/smoke-opencode-resolver.ts
@@ -110,6 +110,9 @@ try {
     fixture.modelIDs.text,
     fixture.modelIDs.vision,
   ])
+  const resolvedModels = parsed.provider?.lmstudio?.models ?? {}
+  assert.equal((resolvedModels[fixture.modelIDs.text] as { tool_call?: boolean }).tool_call, true)
+  assert.equal((resolvedModels[fixture.modelIDs.vision] as { tool_call?: boolean }).tool_call, true)
 
   const packageManifest = join(
     xdg,

--- a/scripts/smoke-opencode.ts
+++ b/scripts/smoke-opencode.ts
@@ -86,7 +86,11 @@ try {
   assert(provider)
   assert.deepEqual(Object.keys(provider.models ?? {}), [fixture.modelIDs.text, fixture.modelIDs.vision])
   assert.deepEqual(provider.whitelist, [fixture.modelIDs.text, fixture.modelIDs.vision])
-  assert.equal((provider.models?.[fixture.modelIDs.vision] as { attachment?: boolean }).attachment, true)
+  const textModel = provider.models?.[fixture.modelIDs.text] as { tool_call?: boolean }
+  const visionModel = provider.models?.[fixture.modelIDs.vision] as { attachment?: boolean; tool_call?: boolean }
+  assert.equal(textModel.tool_call, true)
+  assert.equal(visionModel.attachment, true)
+  assert.equal(visionModel.tool_call, true)
 
   const live = await run(opencode, ["run", "--model", `lmstudio/${fixture.modelIDs.text}`, "SMOKE_PROMPT"], root, env)
   assert.equal(live.code, 0, live.stderr)

--- a/src/plugin/enhance-config.ts
+++ b/src/plugin/enhance-config.ts
@@ -22,9 +22,15 @@ export interface EnhanceConfigResult {
   readonly skippedEmbeddings: number
   readonly skippedUnsupported: number
   readonly serverURL: string
+  readonly toolUse: {
+    readonly default: readonly string[]
+    readonly native: readonly string[]
+    readonly unknown: readonly string[]
+  }
 }
 
 const MAX_OUTPUT_RESERVE = 8_192
+export type ToolUseMode = "default" | "native" | "unknown"
 interface GeneratedState {
   readonly models: Readonly<Record<string, ModelConfig>>
   readonly whitelist?: readonly string[]
@@ -42,6 +48,12 @@ export function effectiveContextLength(model: LMStudioModel): number {
     : Math.min(model.max_context_length, ...loaded)
 }
 
+/** Classify LM Studio's native-vs-default tool handling without disabling tools. */
+export function toolUseMode(model: LMStudioModel): ToolUseMode {
+  const trained = model.capabilities?.trained_for_tool_use
+  return trained === true ? "native" : trained === false ? "default" : "unknown"
+}
+
 export function toModelConfig(model: LMStudioModel & { type: "llm" }): ModelConfig {
   const vision = model.capabilities?.vision === true
   const input: Array<"text" | "image"> = vision ? ["text", "image"] : ["text"]
@@ -51,6 +63,10 @@ export function toModelConfig(model: LMStudioModel & { type: "llm" }): ModelConf
     id: model.key,
     name: model.display_name,
     attachment: vision,
+    // LM Studio supports tools for every LLM. The training flag distinguishes
+    // native handling from its lower-reliability default tool format; it does
+    // not mean that tool calls are unsupported.
+    tool_call: true,
     modalities: {
       input,
       output: ["text"],
@@ -148,6 +164,11 @@ export async function enhanceConfig(config: OpenCodeConfig, log: PluginLogger): 
       skippedEmbeddings: response.models.filter((model) => model.type === "embedding").length,
       skippedUnsupported: response.models.filter((model) => !isGenerativeModel(model) && model.type !== "embedding").length,
       serverURL,
+      toolUse: {
+        default: generative.filter((model) => toolUseMode(model) === "default").map((model) => model.key),
+        native: generative.filter((model) => toolUseMode(model) === "native").map((model) => model.key),
+        unknown: generative.filter((model) => toolUseMode(model) === "unknown").map((model) => model.key),
+      },
     }
     await log("info", "Discovered LM Studio models", result)
     return result

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,7 +1,12 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { LMStudioPlugin } from "../src/index.ts"
-import { effectiveContextLength, enhanceConfig, toModelConfig } from "../src/plugin/enhance-config.ts"
+import {
+  effectiveContextLength,
+  enhanceConfig,
+  toolUseMode,
+  toModelConfig,
+} from "../src/plugin/enhance-config.ts"
 import type { LMStudioModel, OpenCodeConfig, PluginLogger } from "../src/types/index.ts"
 import {
   LMStudioAPIError,
@@ -163,7 +168,7 @@ describe("model mapping", () => {
     })
   })
 
-  it("maps documented vision while leaving tool training and reasoning semantically distinct", () => {
+  it("maps vision and tool support while preserving native-vs-default tool diagnostics", () => {
     const mapped = toModelConfig(model({
       key: "zai-org/glm-4.5v",
       display_name: "GLM 4.5V",
@@ -178,9 +183,12 @@ describe("model mapping", () => {
       id: "zai-org/glm-4.5v",
       name: "GLM 4.5V",
       attachment: true,
+      tool_call: true,
       modalities: { input: ["text", "image"], output: ["text"] },
     })
-    expect(mapped).not.toHaveProperty("tool_call")
+    expect(toolUseMode(model({ capabilities: { vision: false, trained_for_tool_use: true } }))).toBe("native")
+    expect(toolUseMode(model({ capabilities: { vision: false, trained_for_tool_use: false } }))).toBe("default")
+    expect(toolUseMode(model({ capabilities: undefined }))).toBe("unknown")
     expect(mapped).not.toHaveProperty("reasoning")
   })
 })
@@ -188,7 +196,11 @@ describe("model mapping", () => {
 describe("config enhancement", () => {
   it("registers Nemotron and GLM from typed records without name heuristics", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => modelsResponse([
-      model({ key: "nvidia/nemotron-3-nano-omni", display_name: "Nemotron 3 Nano Omni" }),
+      model({
+        key: "nvidia/nemotron-3-nano-omni",
+        display_name: "Nemotron 3 Nano Omni",
+        capabilities: { vision: false, trained_for_tool_use: false },
+      }),
       model({
         key: "zai-org/glm-4.5v",
         display_name: "GLM 4.5V",
@@ -199,20 +211,37 @@ describe("config enhancement", () => {
       model({ type: "future-domain", key: "future/model", display_name: "Future Model" }),
     ])))
     const value = config()
+    const log = logger()
 
-    const result = await enhanceConfig(value, logger())
+    const result = await enhanceConfig(value, log)
 
-    expect(result).toMatchObject({ discovered: 2, skippedEmbeddings: 2, skippedUnsupported: 1 })
+    expect(result).toMatchObject({
+      discovered: 2,
+      skippedEmbeddings: 2,
+      skippedUnsupported: 1,
+      toolUse: {
+        default: ["nvidia/nemotron-3-nano-omni"],
+        native: ["zai-org/glm-4.5v"],
+        unknown: [],
+      },
+    })
+    expect(log).toHaveBeenCalledWith(
+      "info",
+      "Discovered LM Studio models",
+      expect.objectContaining({ toolUse: result?.toolUse }),
+    )
     expect(value.provider?.lmstudio?.options?.baseURL).toBe("http://127.0.0.1:1234/v1")
     expect(value.provider?.lmstudio?.models).toEqual({
       "nvidia/nemotron-3-nano-omni": expect.objectContaining({
         name: "Nemotron 3 Nano Omni",
         attachment: false,
+        tool_call: true,
         modalities: { input: ["text"], output: ["text"] },
       }),
       "zai-org/glm-4.5v": expect.objectContaining({
         name: "GLM 4.5V",
         attachment: true,
+        tool_call: true,
         modalities: { input: ["text", "image"], output: ["text"] },
       }),
     })


### PR DESCRIPTION
## Summary

- advertise tool calls for every discovered LM Studio LLM because LM Studio documents native and default tool-use support
- classify model keys as native, default, or unknown from the typed native v1 capability record and include that signal in structured discovery logs
- document why the plugin does not disable default support or guess at malformed tool calls by scanning assistant text
- extend unit, live OpenCode config, packed-package, and native npm resolver checks for the tool capability contract

## Contract

`trained_for_tool_use: false` does not mean tools are unsupported. LM Studio uses its default tool format for these models, with model-dependent reliability. OpenCode exposes only a `tool_call` support boolean, not native-vs-default quality, so discovered LLMs use `tool_call: true` and diagnostics preserve the distinction.

The plugin does not claim runtime malformed-call detection: LM Studio can return malformed tool-call text as ordinary assistant content, and the installed OpenCode plugin API exposes no unambiguous failure signal for that case.

Primary LM Studio reference: https://lmstudio.ai/docs/advanced/tool-use

## Verification

- `npm run release:check`
- `npm run smoke:opencode`
- `npm run smoke:opencode:acp`
- packed candidate chat, ACP, and native npm resolver on OpenCode 1.17.7 and 1.17.9
- packed candidate Microsoft TUI Test: 5/5 views
- unit suite: 27/27
- coverage: 92.41% statements, 83.63% branches, 97.14% functions, 92.64% lines
- candidate SHA-256: `bdd2d02df3ed881de18eb48a929618d74fd4098001b1f8a410add2990a612e05`
